### PR TITLE
Enable all features for testing and fix compile issue in 'test_come_config' (builder pattern without existing methods)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "chatgpt_rs"
 version = "1.1.6"
 dependencies = [
+ "chatgpt_rs",
  "chrono",
  "derive_builder",
  "eventsource-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ futures-util = { version = "0.3.28", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.28.0", features = ["macros", "rt-multi-thread"] }
+chatgpt_rs = { path = ".", features = ["json", "streams", "postcard"] }
 
 [features]
 default = ["json"]

--- a/examples/streamed.rs
+++ b/examples/streamed.rs
@@ -21,17 +21,15 @@ async fn main() -> Result<()> {
     // Iterating over stream contents
     stream
         .for_each(|each| async move {
-            match each {
-                ResponseChunk::Content {
-                    delta,
-                    response_index: _,
-                } => {
-                    // Printing part of response without the newline
-                    print!("{delta}");
-                    // Manually flushing the standard output, as `print` macro does not do that
-                    stdout().lock().flush().unwrap();
-                }
-                _ => {}
+            if let ResponseChunk::Content {
+                delta,
+                response_index: _,
+            } = each
+            {
+                // Printing part of response without the newline
+                print!("{delta}");
+                // Manually flushing the standard output, as `print` macro does not do that
+                stdout().lock().flush().unwrap();
             }
         })
         .await;

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -95,10 +95,11 @@ pub mod test {
     async fn test_some_config() -> crate::Result<()> {
         let client = ChatGPT::new_with_config(
             std::env::var("TEST_API_KEY")?,
-            ModelConfiguration::default()
-                .temperature(0.9)
-                .reply_count(3)
-                .build(),
+            ModelConfiguration {
+                temperature: 0.9,
+                reply_count: 3,
+                ..Default::default()
+            },
         )?;
         let response = client
             .send_message("Could you give me names of three popular Rust web frameworks?")


### PR DESCRIPTION
When running `cargo test`, it fails, because it needs some features which are not enabled by default, this PR should enable all features via a workaround (see https://github.com/rust-lang/cargo/issues/2911) by depending it self with enabled features for dev-dependencies.

Also there was an issue with a non-existing builder pattern. I fixed this for now without adding these methods with the "default" pattern. (And fixed a clippy lint match -> if let)