### PR TITLE
Streaming Response fixes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use reqwest::header::AUTHORIZATION;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{self, Proxy};
+#[cfg(feature = "streams")]
+use reqwest::Response;
 use std::time::Duration;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;

--- a/src/client.rs
+++ b/src/client.rs
@@ -121,7 +121,10 @@ impl ChatGPT {
     ///
     /// Conversations record message history.
     pub fn new_conversation(&self) -> Conversation {
-        self.new_conversation_directed(format!("You are ChatGPT, an AI model developed by OpenAI. Answer as concisely as possible."))
+        self.new_conversation_directed(
+            "You are ChatGPT, an AI model developed by OpenAI. Answer as concisely as possible."
+                .to_string(),
+        )
     }
 
     /// Starts a new conversation with a specified starting message.
@@ -266,6 +269,7 @@ impl ChatGPT {
     ) -> crate::Result<impl Stream<Item = ResponseChunk>> {
         use eventsource_stream::Eventsource;
         use futures_util::StreamExt;
+
         let response_stream = self
             .client
             .post(self.config.api_url.clone())

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use reqwest::header::AUTHORIZATION;
 use reqwest::header::{HeaderMap, HeaderValue};
-use reqwest::{self, Proxy, Response};
+use reqwest::{self, Proxy};
 use std::time::Duration;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;

--- a/src/err.rs
+++ b/src/err.rs
@@ -39,5 +39,5 @@ pub enum Error {
     IOError(#[from] tokio::io::Error),
     /// Most likely env var not provided
     #[error("Error while trying to access an environment variable: {0}")]
-    VarError(#[from] VarError),
+    VarError(#[from] VarError)
 }

--- a/src/err.rs
+++ b/src/err.rs
@@ -39,5 +39,5 @@ pub enum Error {
     IOError(#[from] tokio::io::Error),
     /// Most likely env var not provided
     #[error("Error while trying to access an environment variable: {0}")]
-    VarError(#[from] VarError)
+    VarError(#[from] VarError),
 }


### PR DESCRIPTION
Streaming errors now return `ClientError` instead of silently failing whenever a bad status code is returned.

Fixes #48 