### PR TITLE
fixes chatgpt_rs#61

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -54,6 +54,7 @@ impl ChatGPT {
         );
         let client = reqwest::ClientBuilder::new()
             .default_headers(headers)
+            .timeout(Duration::from_secs(10))
             .build()?;
         Ok(Self { client, config })
     }


### PR DESCRIPTION
This pull request adds a timeout to the "new_with_config" reqwest client creation. This makes the code's performance more stable in production environments as it avoids reqwest's default infinite timeout. Given that ChatGPT is under heavy load and will sometimes hang, this is quite needed.

See issue: chatgpt_rs#61.

Thanks again for the library! :)