### PR TITLE
feat: max_tokens allow option value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1180,6 +1180,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.31.0", features = ["macros"] }
 serde = { version = "1.0.179", features = ["derive"] }
 serde_json = { version = "1.0.104", optional = true }
 thiserror = "1.0.44"
-url = "2.4.0"
+url = { version = "2.4.0", features = ["serde"] }
 derive_builder = "0.12.0"
 
 postcard = { version = "1.0.6", features = ["alloc"], optional = true }
@@ -48,25 +48,9 @@ lazy_static = "1.4.0"
 
 [features]
 default = ["json"]
-streams = [
-    "dep:eventsource-stream",
-    "dep:futures-util",
-    "dep:futures",
-    "reqwest/stream",
-]
-functions = [
-    "dep:gpt_fn_macros",
-    "dep:schemars",
-    "dep:async-trait",
-    "dep:serde_json",
-    "dep:async-recursion",
-]
-functions_extra = [
-    "schemars/chrono",
-    "schemars/url",
-    "schemars/uuid1",
-    "schemars/either",
-]
+streams = ["dep:eventsource-stream", "dep:futures-util", "dep:futures", "reqwest/stream"]
+functions = ["dep:gpt_fn_macros", "dep:schemars", "dep:async-trait", "dep:serde_json", "dep:async-recursion"]
+functions_extra = ["schemars/chrono", "schemars/url", "schemars/uuid1", "schemars/either"]
 json = ["dep:serde_json", "tokio/fs"]
 postcard = ["dep:postcard", "tokio/fs"]
 

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -139,14 +139,36 @@ pub mod test {
         let client = ChatGPT::new_with_config(
             std::env::var("TEST_API_KEY")?,
             ModelConfiguration {
-                max_tokens: 10,
+                max_tokens: Some(10),
                 ..Default::default()
             },
         )?;
         let response = client
             .send_message("Could you give me names of three popular Rust web frameworks?")
             .await?;
-        assert_eq!( response.message_choices.first().unwrap().finish_reason, "length".to_string());
+        assert_eq!(
+            response.message_choices.first().unwrap().finish_reason,
+            "length".to_string()
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_default_max_token_config() -> crate::Result<()> {
+        let client = ChatGPT::new_with_config(
+            std::env::var("TEST_API_KEY")?,
+            ModelConfiguration {
+                max_tokens: None,
+                ..Default::default()
+            },
+        )?;
+        let response = client
+            .send_message("Could you give me names of three popular Rust web frameworks?")
+            .await?;
+        assert_eq!(
+            response.message_choices.first().unwrap().finish_reason,
+            "stop".to_string()
+        );
         Ok(())
     }
 }

--- a/src/chatgpt.rs
+++ b/src/chatgpt.rs
@@ -158,7 +158,6 @@ pub mod test {
         let client = ChatGPT::new_with_config(
             std::env::var("TEST_API_KEY")?,
             ModelConfiguration {
-                max_tokens: None,
                 ..Default::default()
             },
         )?;
@@ -167,7 +166,7 @@ pub mod test {
             .await?;
         assert_eq!(
             response.message_choices.first().unwrap().finish_reason,
-            "stop".to_string()
+            "length".to_string()
         );
         Ok(())
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
-use std::time::Duration;
 use std::{fmt::Display, str::FromStr};
+use std::time::Duration;
 
 #[cfg(feature = "functions")]
 use crate::functions::FunctionValidationStrategy;

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,9 +4,10 @@ use std::time::Duration;
 #[cfg(feature = "functions")]
 use crate::functions::FunctionValidationStrategy;
 use derive_builder::Builder;
+use serde::Serialize;
 
 /// The struct containing main configuration for the ChatGPT API
-#[derive(Debug, Clone, PartialEq, PartialOrd, Builder)]
+#[derive(Serialize, Debug, Clone, PartialEq, PartialOrd, Builder)]
 #[builder(default, setter(into))]
 pub struct ModelConfiguration {
     /// The GPT version used.
@@ -16,6 +17,7 @@ pub struct ModelConfiguration {
     /// Controls diversity via nucleus sampling, not recommended to use with temperature
     pub top_p: f32,
     /// Controls the maximum number of tokens to generate in the completion
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
     /// Determines how much to penalize new tokens passed on their existing presence so far
     pub presence_penalty: f32,
@@ -51,7 +53,7 @@ impl Default for ModelConfiguration {
 }
 
 /// The engine version for ChatGPT
-#[derive(Debug, Default, Copy, Clone, PartialEq, PartialOrd)]
+#[derive(Serialize, Debug, Default, Copy, Clone, PartialEq, PartialOrd)]
 #[allow(non_camel_case_types)]
 pub enum ChatGPTEngine {
     /// Standard engine: `gpt-3.5-turbo`

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
-use std::{fmt::Display, str::FromStr};
 use std::time::Duration;
+use std::{fmt::Display, str::FromStr};
 
 #[cfg(feature = "functions")]
 use crate::functions::FunctionValidationStrategy;
@@ -16,7 +16,7 @@ pub struct ModelConfiguration {
     /// Controls diversity via nucleus sampling, not recommended to use with temperature
     pub top_p: f32,
     /// Controls the maximum number of tokens to generate in the completion
-    pub max_tokens: u32,
+    pub max_tokens: Option<u32>,
     /// Determines how much to penalize new tokens passed on their existing presence so far
     pub presence_penalty: f32,
     /// Determines how much to penalize new tokens based on their existing frequency so far
@@ -38,7 +38,7 @@ impl Default for ModelConfiguration {
             engine: Default::default(),
             temperature: 0.5,
             top_p: 1.0,
-            max_tokens: 16,
+            max_tokens: Some(16),
             presence_penalty: 0.0,
             frequency_penalty: 0.0,
             reply_count: 1,

--- a/src/functions/types.rs
+++ b/src/functions/types.rs
@@ -73,7 +73,7 @@ pub enum FunctionCallingMode {
 }
 
 /// Determines how this client will validate function calls.
-#[derive(Debug, Copy, Clone, Default, PartialOrd, PartialEq)]
+#[derive(Serialize, Debug, Copy, Clone, Default, PartialOrd, PartialEq)]
 pub enum FunctionValidationStrategy {
     /// Whenever ChatGPT attempts to call an undefined function, or calls a functions with wrong parameters, sends a `System` message correcting it.
     Strict,

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,6 +81,7 @@ pub struct CompletionRequest<'a> {
     /// Controls diversity via nucleus sampling, not recommended to use with temperature
     pub top_p: f32,
     /// Controls the maximum number of tokens to generate in the completion
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
     /// Determines how much to penalize new tokens based on their existing frequency so far
     pub frequency_penalty: f32,

--- a/src/types.rs
+++ b/src/types.rs
@@ -81,7 +81,7 @@ pub struct CompletionRequest<'a> {
     /// Controls diversity via nucleus sampling, not recommended to use with temperature
     pub top_p: f32,
     /// Controls the maximum number of tokens to generate in the completion
-    pub max_tokens: u32,
+    pub max_tokens: Option<u32>,
     /// Determines how much to penalize new tokens based on their existing frequency so far
     pub frequency_penalty: f32,
     /// Determines how much to penalize new tokens pased on their existing presence so far


### PR DESCRIPTION
The `max_token` added in #60 is now available as an option.

Unused `max_token`, the API should be treated as unlimited tokens.