### PR TITLE
readme: add missing required CompletionResponse import

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can see more practical examples in the `examples` directory.
 
 ```rust
 use chatgpt::prelude::*;
+use chatgpt::types::{CompletionResponse};
 
 #[tokio::main]
 async fn main() -> Result<()> {


### PR DESCRIPTION
Add the required CompletionResponse import to the example in the readme so the code actually builds/runs.