### PR TITLE
use connect_timeout instead of timeout

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -53,7 +53,7 @@ impl ChatGPT {
         );
         let client = reqwest::ClientBuilder::new()
             .default_headers(headers)
-            .timeout(config.timeout)
+            .connect_timeout(config.timeout)
             .build()?;
         Ok(Self { client, config })
     }


### PR DESCRIPTION
timeout is applied from when the request starts connecting until the response body has finished. 

this will break streaming response that takes longer than the default 10s timeout.